### PR TITLE
Update requirements.txt with scikit-learn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ numpy
 Cython
 POT
 scipy 
-sklearn
+scikit-learn
 torch


### PR DESCRIPTION
Usage of sklearn has been deprecated to install the package. Updated to scikit-learn in the requirements.txt file